### PR TITLE
changed target framework to net6

### DIFF
--- a/finish/StorageQueueApp.csproj
+++ b/finish/StorageQueueApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/start/StorageQueueApp.csproj
+++ b/start/StorageQueueApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
During the [excercise](https://docs.microsoft.com/it-it/learn/modules/communicate-between-apps-with-azure-queue-storage/7-exercise-implement-enqueue), when I tried to run the app in the Cloud Shell sandbox I received the following error:

```
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '3.1.0' (x64) was not found.
  - The following frameworks were found:
      6.0.5 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.1.0&arch=x64&rid=cbld.10-x64
```

To solve the problem I had to update the target framework from netcoreapp3.1 to net6

-------
Another issue that I faced is that the value of environment variable STORAGE_CONNECTION_STRING was like overridden when running the app on che Clod Shell sandbox environment.

Running the command:
`echo $STORAGE_CONNECTION_STRING`
 I see the correct value, but printing the connectionString variable using the following code I noticed a different value (I don't know why, maybe cloud shell override it with the storage account associated?)

```charp
            string connectionString = Environment.GetEnvironmentVariable("STORAGE_CONNECTION_STRING");
            Console.WriteLine("-------------------");
            Console.WriteLine(connectionString);
            Console.WriteLine("-------------------");
            QueueClient queueClient = new QueueClient(connectionString, "newsqueue");
            await queueClient.CreateIfNotExistsAsync();
```

```
-------------------
DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=stlearnstoragequeue;AccountKey=NtOKgqpuG4N8TS73oR08wSD9/uENZmv5AZXDYHuo1jI8QALr8WwWJUdK/aSHDsRA5fYY0qNWbp4NBsbK+P7Wmw==
-------------------
```

To solve this issue I changed the environment variable name from STORAGE_CONNECTION_STRING to MY_STORAGE_CONNECTION_STRING both on the Azure CLI command and on the c# code.
Maybe the Excercise instructions must be reviewed in order to run on the Cloud Shell sandbox, and than the code should be changed as well.
