### PR TITLE
Update project files to utilize .Net 7

### DIFF
--- a/finish/StorageQueueApp.csproj
+++ b/finish/StorageQueueApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net7</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/start/StorageQueueApp.csproj
+++ b/start/StorageQueueApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net7</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
During recent activity with Azure Learn Sandbox involving this repo - I was getting such issue:
`$ dotnet run
You must install or update .NET to run this application.

App: /home/xyz/mslearn-communicate-with-storage-queues/start/bin/Debug/net6/StorageQueueApp
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '6.0.0' (x64)
.NET location: /usr/share/dotnet

The following frameworks were found:
  7.0.5 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=6.0.0&arch=x64&rid=mariner.2.0-x64`

and after update of such to .Net 7:
`<TargetFramework>net7</TargetFramework>`

sample was able to run properly.

Thus proposing bump up to .Net 7 in this PR.